### PR TITLE
set settings store to system

### DIFF
--- a/xExtension-RssBridge/configure.phtml
+++ b/xExtension-RssBridge/configure.phtml
@@ -3,7 +3,7 @@
 	<div class="form-group">
 		<label class="group-name" for="rss_bridge_url"><?php echo _t('ext.rssbridge.url'); ?></label>
 		<div class="group-controls">
-			<input type="url" name="rss_bridge_url" id="rss_bridge_url" value="<?php echo FreshRSS_Context::$user_conf->rss_bridge_url; ?>">
+			<input type="url" name="rss_bridge_url" id="rss_bridge_url" value="<?php echo FreshRSS_Context::$system_conf->rss_bridge_url; ?>">
 		</div>
 	</div>
 

--- a/xExtension-RssBridge/extension.php
+++ b/xExtension-RssBridge/extension.php
@@ -9,14 +9,14 @@ class RssBridgeExtension extends Minz_Extension {
 		$this->registerTranslates();
 
 		if (Minz_Request::isPost()) {
-			FreshRSS_Context::$user_conf->rss_bridge_url =
+			FreshRSS_Context::$system_conf->rss_bridge_url =
 				Minz_Request::param('rss_bridge_url', '');
-			FreshRSS_Context::$user_conf->save();
+			FreshRSS_Context::$system_conf->save();
 		}
 	}
 
 	public static function RssBridgeDetect($url) {
-		$bridge = FreshRSS_Context::$user_conf->rss_bridge_url .
+		$bridge = FreshRSS_Context::$system_conf->rss_bridge_url .
 			'?action=detect&format=Atom&url=' . rawurlencode($url);
 
 		if(strpos(get_headers($bridge)[0], '301')) {


### PR DESCRIPTION
Hi,
I've experienced that when setting the RSS-Bridge-URL the admin could use the bridge but every other user got `rss_bridge_url does not exist in configuration` in their logs (and they couldn't set it themselves since it is a system extension).

So I changed the settings target from `user` to `system`.

An alternative solution could have been to set the extension from system to user.
But since you've explicitly changed the extension to system in a previous commit (c3fcf84a1d680cbbcf1e610205af3a2c004bd554), I guess this way should be more what you would prefer.